### PR TITLE
In order to resolve NDEX-405, we need to make sure that all projects use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,21 @@
   <dependencies>
   		<!-- 3rd party libraries -->
   		
-  		<dependency>
-  			<groupId>com.fasterxml.jackson.core</groupId>
-  			<artifactId>jackson-databind</artifactId>
-  			<version>2.3.4</version>
-		</dependency>
-  		
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.2</version>
+        </dependency>  		
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -21,4 +30,25 @@
 			<version>4.11</version>
 		</dependency>
   </dependencies>
+  
+<!--  
+  <properties>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+  </properties>
+-->
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+
 </project>


### PR DESCRIPTION
the same version of Jackson library (2.5.2).  So we update the pom
file to use Jackson 2.5.2.  Also, we added source and target 1.7 for the
configuration of maven compiler to make sure that java 1.7 is used as
source and target.  If we don't add the compile configuiration, then
Java 1.5 conventions are used and we get compilation errors.