### PR TITLE
Modified constructor public NdexException(NDExError ndexError) to

### DIFF
--- a/src/main/java/org/ndexbio/model/exceptions/NdexException.java
+++ b/src/main/java/org/ndexbio/model/exceptions/NdexException.java
@@ -16,7 +16,7 @@ public class NdexException extends Exception
     
     public NdexException(NDExError ndexError)
     {
-        super();
+        super(ndexError.getMessage());
         this.ndexError = ndexError;
     }    
     public NdexException(String message)


### PR DESCRIPTION
initialize superconstructor with the message from
ndexError.getMessage():

super(ndexError.getMessage());