### PR TITLE
Cx2test

### DIFF
--- a/src/main/java/org/ndexbio/cx2/converter/ConverterUtilities.java
+++ b/src/main/java/org/ndexbio/cx2/converter/ConverterUtilities.java
@@ -1,44 +1,74 @@
 package org.ndexbio.cx2.converter;
 
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.ndexbio.model.exceptions.NdexException;
 
 public class ConverterUtilities {
-
+    
+        protected static final Pattern passThruPattern = Pattern.compile("^COL=(.*),T=.*$");
 	
-	/** covert a cytoscape string VP value into a CX2 VP object value
-	 * 
-	 * @param cytoscapeDataType
-	 * @param value
-	 * @return
-	 * @throws NdexException
+	/** 
+          * Convert a cytoscape string VP value into a CX2 VP object value using
+          * {@link java.lang.Double#valueOf}, {@link java.lang.Integer#valueOf}, 
+          * {@link java.lang.Long#valueOf}, and {@link java.lang.Boolean#valueOf} to
+          * perform conversion. (Strings are returned as is)
+          * 
+	 * @param cytoscapeDataType datatype to convert to. Should be one of the following
+          *                           string, double, integer, long, boolean
+	 * @param value The value to convert.
+	 * @return The converted result along with any warnings about conversion
+	 * @throws NdexException if either parameter passed in is {@code null}, if there was a
+         *                        conversion error, or if the {@code cytoscapeDataType} is not
+         *                        one of the valid types listed above
 	 */
-	public static Object cvtStringValueToObj(String cytoscapeDataType, String value) throws NdexException {
-		if ( cytoscapeDataType.equals("string")) {
-			return value;
-		} else if (cytoscapeDataType.equals("double")) {
-		   return Double.valueOf(value);
-		}else if (cytoscapeDataType.equals("long")) {
-			try {
-			   return Long.valueOf(value);
-			} catch (NumberFormatException e) {
-				System.err.println("Value " + value + " is not a valid string for long. NDEx is converting it to long from double.");
-				return Long.valueOf(Double.valueOf(value).longValue());		
-			}
-		}else if (cytoscapeDataType.equals("integer")) {
-			try {
-				return Integer.valueOf(value);
-			}  catch (NumberFormatException e) {
-				System.err.println("Value " + value + " is not a valid string for integer. NDEx is converting it to long from double.");
-				return Integer.valueOf(Double.valueOf(value).intValue());		
-			}
-		}else if (cytoscapeDataType.equals("boolean")) {
-				   return Boolean.valueOf(value);
-		} else {
-			throw new NdexException ("Unsupported cy data type found:" + cytoscapeDataType);
+	public static ConverterUtilitiesResult cvtStringValueToObj(final String cytoscapeDataType,
+                final String value) throws NdexException {
+	        if (cytoscapeDataType == null){
+                    throw new NdexException("Unsupported cy data type: <null>");
+                 }
+                 if (value == null){
+                     throw new NdexException("Unsupported cy data value: <null>");
+                 }
+                 
+                 if ( cytoscapeDataType.equals("string")) {
+			return new ConverterUtilitiesResult(value, null);
 		}
+                 try {
+                    if (cytoscapeDataType.equals("double")) {
+
+                      return new ConverterUtilitiesResult(Double.valueOf(value), null);
+                    }
+
+                    if (cytoscapeDataType.equals("long")) {
+                           try {
+                              return new ConverterUtilitiesResult(Long.valueOf(value), null);
+                           } catch (NumberFormatException e) {
+                                      return new ConverterUtilitiesResult(Long.valueOf(Double.valueOf(value).longValue()),
+                                            Arrays.asList("Value " + value
+                                                    + " is not a valid string for long. NDEx is converting it to long from double: " + e.getMessage()));		
+                           }
+                   }
+                    if (cytoscapeDataType.equals("integer")) {
+                           try {
+                                   return new ConverterUtilitiesResult(Integer.valueOf(value), null);
+                           }  catch (NumberFormatException e) {
+                                   return new ConverterUtilitiesResult(Integer.valueOf(Double.valueOf(value).intValue()),
+                                           Arrays.asList("Value " + value
+                                                   + " is not a valid string for integer. NDEx is converting it to integer from double: " + e.getMessage()));		
+                           }
+                   }
+
+                    if (cytoscapeDataType.equals("boolean")) {
+                       return new ConverterUtilitiesResult(Boolean.valueOf(value), null);
+                   } 
+                 } catch(NumberFormatException nfe){
+                     throw new NdexException("Error converting data to type: " + cytoscapeDataType + " : " + nfe.getMessage());
+                 }
+		throw new NdexException ("Unsupported cy data type found: " + cytoscapeDataType);
+		
 	}
 
 	/**
@@ -47,13 +77,16 @@ public class ConverterUtilities {
 	 * @return
 	 * @throws NdexException
 	 */
-    public static String getPassThroughMappingAttribute(String mappingString) throws NdexException {
-		Pattern p = Pattern.compile("^COL=(.*),T=.*$");
-		Matcher m = p.matcher(mappingString);
-		if ( m.matches() ) {
-			return  m.group(1);
-		}
-		throw new NdexException("Malformed mapping string for Passthrough mapping: " + mappingString);
+    public static String getPassThroughMappingAttribute(final String mappingString) throws NdexException {
+            if (mappingString == null){
+                throw new NdexException("Mapping string for Passthrough mapping is null");
+            }
+           Matcher m = ConverterUtilities.passThruPattern.matcher(mappingString);
+           if ( m.matches() ) {
+                   return  m.group(1);
+           }
+           throw new NdexException("Malformed mapping string for Passthrough mapping: "
+                   + mappingString);
     }
 
 

--- a/src/main/java/org/ndexbio/cx2/converter/ConverterUtilitiesResult.java
+++ b/src/main/java/org/ndexbio/cx2/converter/ConverterUtilitiesResult.java
@@ -1,0 +1,56 @@
+package org.ndexbio.cx2.converter;
+
+import java.util.List;
+
+/**
+ * Pojo class to hold result from 
+ * {@link org.ndexbio.cx2.converter.ConverterUtilities#cvtStringValueToObj}
+ * method
+ * 
+ * @author churas
+ */
+public class ConverterUtilitiesResult {
+    
+    private List<String> _warnings;
+    private Object _result;
+    
+    /**
+     * Constructor
+     * @param result The result 
+     * @param warnings Any warnings generated from result
+     */
+    public ConverterUtilitiesResult(final Object result, List<String> warnings){
+        _warnings = warnings;
+        _result = result;
+    }
+    
+    /**
+     * Gets warnings passed in via constructor
+     * @return Any warnings or {@code null} if none passed in
+     */
+    public List<String> getWarnings(){
+        return _warnings;
+    }
+    
+    /**
+     * Denotes whether any warnings were passed in via the constructor
+     * 
+     * @return {@code TRUE} if the warnings passed in via constructor
+     *         is not {@code null} and has at least one entry otherwise
+     *         {@code FALSE}
+     */
+    public boolean hasWarnings(){
+        if (_warnings == null || _warnings.isEmpty()){
+            return false;
+        }
+        return true;
+    }
+    
+    /**
+     * Gets result
+     * @return The result passed in via constructor
+     */
+    public Object getResult(){
+        return _result;
+    }
+}

--- a/src/test/java/org/ndexbio/cx2/converter/CX2VPHolderTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/CX2VPHolderTest.java
@@ -1,0 +1,60 @@
+package org.ndexbio.cx2.converter;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.ndexbio.cx2.aspect.element.core.CxEdgeBypass;
+import org.ndexbio.cx2.aspect.element.core.CxNodeBypass;
+import org.ndexbio.cx2.aspect.element.core.CxVisualProperty;
+import org.ndexbio.cx2.aspect.element.core.DefaultVisualProperties;
+
+/**
+ *
+ * @author churas
+ */
+public class CX2VPHolderTest {
+    
+    @Test
+    public void testGettersAndSetters(){
+        CX2VPHolder holder = new CX2VPHolder();
+        CxVisualProperty visProp = holder.getStyle();
+        assertNotNull(visProp);
+        assertTrue(visProp.isEmpty());
+        
+        List<CxNodeBypass> nodeByPasses = holder.getNodeBypasses();
+        assertTrue(nodeByPasses.isEmpty());
+        List<CxEdgeBypass> edgeByPasses = holder.getEdgeBypasses();
+        assertTrue(edgeByPasses.isEmpty());
+        
+        CxVisualProperty newVis = new CxVisualProperty();
+        DefaultVisualProperties defaultProps = new DefaultVisualProperties();
+        Map<String, Object> networkProperties = new HashMap<>();
+        networkProperties.put("hi", "there");
+        defaultProps.setNetworkProperties(networkProperties);
+        newVis.setDefaultProps(defaultProps);
+        holder.setStyle(newVis);
+        
+        CxNodeBypass nodeByPass = new CxNodeBypass();
+        nodeByPass.setId(5);
+        holder.setNodeBypasses(Arrays.asList(nodeByPass));
+        
+        CxEdgeBypass edgeByPass = new CxEdgeBypass();
+        edgeByPass.setId(6);
+        holder.setEdgeBypasses(Arrays.asList(edgeByPass));
+        
+        CxVisualProperty resVis = holder.getStyle();
+        assertTrue(resVis.getDefaultProps().getNetworkProperties().containsKey("hi"));
+   
+        
+        assertEquals(5, holder.getNodeBypasses().get(0).getId());
+        
+        assertEquals(6, holder.getEdgeBypasses().get(0).getId());
+        
+        
+    }
+    
+}

--- a/src/test/java/org/ndexbio/cx2/converter/ConverterUtilitiesResultTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/ConverterUtilitiesResultTest.java
@@ -1,0 +1,33 @@
+package org.ndexbio.cx2.converter;
+
+import java.util.Arrays;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ *
+ * @author churas
+ */
+public class ConverterUtilitiesResultTest {
+    
+    @Test
+    public void testGettersAndSetters(){
+        ConverterUtilitiesResult res = new ConverterUtilitiesResult(null, null);
+        assertNull(res.getWarnings());
+        assertNull(res.getResult());
+        assertFalse(res.hasWarnings());
+
+        res = new ConverterUtilitiesResult("boo", Arrays.asList("hi"));
+        assertEquals("hi", res.getWarnings().get(0));
+        assertEquals("boo", res.getResult());
+        assertTrue(res.hasWarnings());
+        
+        
+        res = new ConverterUtilitiesResult(5L, Arrays.asList());
+        assertTrue(res.getWarnings().isEmpty());
+        assertEquals(5L, res.getResult());
+        assertFalse(res.hasWarnings());
+        
+        
+    }
+}

--- a/src/test/java/org/ndexbio/cx2/converter/ConverterUtilitiesTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/ConverterUtilitiesTest.java
@@ -21,20 +21,152 @@ public class ConverterUtilitiesTest {
         }
     }
     
-    @Test public void testPassingInStringWithNull() throws NdexException {
-        assertNull(ConverterUtilities.cvtStringValueToObj("string", null));
+    @Test
+    public void testPassingInUnsupportedCapitalizedDataType(){
+        try {
+            ConverterUtilities.cvtStringValueToObj("String", "hello");
+            fail("Expected NdexException");
+        } catch(NdexException ne){
+            assertEquals("Unsupported cy data type found: String", ne.getMessage());
+        }
     }
     
-    @Test public void testPassingInStringWithValidValue() throws NdexException {
-        assertEquals("foo", ConverterUtilities.cvtStringValueToObj("string", "foo"));
+    @Test
+    public void testPassingInUnsupportedDataType(){
+        try {
+            ConverterUtilities.cvtStringValueToObj("blah", "hello");
+            fail("Expected NdexException");
+        } catch(NdexException ne){
+            assertEquals("Unsupported cy data type found: blah", ne.getMessage());
+        }
     }
     
-    @Test public void testPassingInDoubleWithNull() throws NdexException {
+    @Test 
+    public void testPassingInStringWithNull() throws NdexException {
+        try {
+            ConverterUtilities.cvtStringValueToObj("string", null);
+            fail("Expected NdexException");
+        } catch(NdexException ne){
+            assertEquals("Unsupported cy data value: <null>", ne.getMessage());
+        }
+    }
+
+    @Test 
+    public void testPassingInStringWithValidValue() throws NdexException {
+        ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("string", "foo");
+        assertEquals("foo", res.getResult());
+        assertNull(res.getWarnings());
+    }
+
+    
+    @Test 
+    public void testPassingInDoubleWithNull() throws NdexException {
         try {
             ConverterUtilities.cvtStringValueToObj("double", null);
             fail("Expected NdexException");
         } catch(NdexException ne){
-            
+            assertEquals("Unsupported cy data value: <null>", ne.getMessage());
         }
+    }
+    
+    @Test 
+    public void testPassingInDoubleWithInvalidValue() throws NdexException {
+        try {
+            ConverterUtilities.cvtStringValueToObj("double", "boo");
+            fail("Expected NdexException");
+        } catch(NdexException ne){
+            assertEquals("Error converting data to type: double : For input string: \"boo\"",
+                    ne.getMessage());
+        }
+    }
+    
+    @Test 
+    public void testPassingInDoubleWithValidValue() throws NdexException {
+
+        ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("double", "22.88");
+        assertEquals(22.88, res.getResult());
+        assertNull(res.getWarnings());
+    }
+    
+    @Test 
+    public void testPassingInIntegerWithValidValue() throws NdexException {
+
+        ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("integer", "9");
+        assertEquals(9, res.getResult());
+        assertNull(res.getWarnings());
+    }
+    
+    @Test 
+    public void testPassingInLongWithValidValue() throws NdexException {
+
+        ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("long", "567");
+        assertEquals(567L, res.getResult());
+        assertNull(res.getWarnings());
+    }
+    
+    @Test 
+    public void testPassingInBooleanWithValidValue() throws NdexException {
+         ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("boolean", "true");
+          assertEquals(Boolean.TRUE, res.getResult());
+          assertNull(res.getWarnings());
+          
+          res = ConverterUtilities.cvtStringValueToObj("boolean", "false");
+          assertEquals(Boolean.FALSE, res.getResult());
+          assertNull(res.getWarnings());
+    }
+    
+    @Test 
+    public void testPassingInBooleanWithInvalidValue() throws NdexException {
+         ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("boolean", "notvalid");
+          assertEquals(Boolean.FALSE, res.getResult());
+          assertNull(res.getWarnings());     
+    }
+    
+    @Test 
+    public void testPassingInDoubleWithDataTypeAsLong() throws NdexException {
+
+        ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("long", "1.5");
+        assertEquals(1L, res.getResult());
+        assertEquals(1, res.getWarnings().size());
+        assertEquals("Value 1.5 is not a valid string for long. "
+                + "NDEx is converting it to long from double: For "
+                + "input string: \"1.5\"", res.getWarnings().get(0));
+    }
+    
+    @Test 
+    public void testPassingInDoubleWithDataTypeAsInteger() throws NdexException {
+
+        ConverterUtilitiesResult res = ConverterUtilities.cvtStringValueToObj("integer", "53.8");
+        assertEquals(53, res.getResult());
+        assertEquals(1, res.getWarnings().size());
+        assertEquals("Value 53.8 is not a valid string for integer. "
+                + "NDEx is converting it to integer from double: For "
+                + "input string: \"53.8\"", res.getWarnings().get(0));
+    }
+    
+    @Test
+    public void testgetPassThroughMappingAttributeNullArgument(){
+        try {
+            ConverterUtilities.getPassThroughMappingAttribute(null);
+            fail("Expected NDexException");
+        } catch(NdexException ne){
+            assertEquals("Mapping string for Passthrough mapping is null", ne.getMessage());
+        }
+    }
+    
+    @Test
+    public void testgetPassThroughMappingAttributeEmptyString(){
+        try {
+            ConverterUtilities.getPassThroughMappingAttribute("");
+            fail("Expected NDexException");
+        } catch(NdexException ne){
+            assertEquals("Malformed mapping string for Passthrough mapping: ", ne.getMessage());
+        }
+    }
+    
+    @Test
+    public void testgetPassThroughMappingAttributeValidString() throws NdexException {
+         String res = ConverterUtilities.getPassThroughMappingAttribute("COL=hello,T=something");
+         assertEquals("hello", res);
     }
 }

--- a/src/test/java/org/ndexbio/cx2/converter/ConverterUtilitiesTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/ConverterUtilitiesTest.java
@@ -1,0 +1,40 @@
+package org.ndexbio.cx2.converter;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.ndexbio.model.exceptions.NdexException;
+
+/**
+ *
+ * @author churas
+ */
+public class ConverterUtilitiesTest {
+    
+    
+    @Test
+    public void testPassingInNullDataType(){
+        try {
+            ConverterUtilities.cvtStringValueToObj(null, "1.0");
+            fail("Expected NdexException");
+        } catch(NdexException ne){
+            assertEquals("Unsupported cy data type: <null>", ne.getMessage());
+        }
+    }
+    
+    @Test public void testPassingInStringWithNull() throws NdexException {
+        assertNull(ConverterUtilities.cvtStringValueToObj("string", null));
+    }
+    
+    @Test public void testPassingInStringWithValidValue() throws NdexException {
+        assertEquals("foo", ConverterUtilities.cvtStringValueToObj("string", "foo"));
+    }
+    
+    @Test public void testPassingInDoubleWithNull() throws NdexException {
+        try {
+            ConverterUtilities.cvtStringValueToObj("double", null);
+            fail("Expected NdexException");
+        } catch(NdexException ne){
+            
+        }
+    }
+}


### PR DESCRIPTION
Added some unit tests to a few classes in `org.ndexbio.cx2.converter` The main change was to `ConverterUtilities` class where `cvtStringValueToObj` now should only raise an `NdexException` for big errors and results are returned in `ConverterUtilitiesResult` object to allow caller to obtain any non fatal issues encountered during parsing. 

**NOTE:** This is a **BREAKING** change cause `CXToCX2Converter` and `CXToCX2ServerSideConverter` classes need to be adjusted to consume the `ConverterUtilitiesResult` object and to catch the `NdexException` possibly raised. 