### PR TITLE
Disable the default value generation for now because the current method has a bug.

### DIFF
--- a/src/main/java/org/ndexbio/cx2/converter/AspectAttributeStatEntry.java
+++ b/src/main/java/org/ndexbio/cx2/converter/AspectAttributeStatEntry.java
@@ -39,13 +39,14 @@ public class AspectAttributeStatEntry {
 	}
 	
 	public void addValue (Object v) {
-		Long s1 = valueHolder.get(v);
+		return;
+		/*Long s1 = valueHolder.get(v);
 		if ( s1 == null ) {
 			if ( valueHolder.size() < distinctCount)
 				valueHolder.put(v, Long.valueOf(1));
 		} else {
 			valueHolder.put(v, s1.longValue() + 1);			
-		}
+		} */
 	}
 	
 	public ATTRIBUTE_DATA_TYPE getDataType () {return datatype;}

--- a/src/test/java/org/ndexbio/cx2/converter/AspectAttributeStatEntryTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/AspectAttributeStatEntryTest.java
@@ -52,13 +52,22 @@ public class AspectAttributeStatEntryTest {
 			e.addValue("foo");
 		}
 		
-		assertEquals("foo", e.getDefaultValue());
+		//should change this back in the future.
+		//assertEquals("foo", e.getDefaultValue());
+		
+		// for now when we turn of the default value
+		assertEquals(null, e.getDefaultValue());
 		
 		for ( int i = 0 ; i < 100 ; i ++  ) {
 			e.addValue("bar");
 		}
 		
-		assertEquals("bar", e.getDefaultValue());
+		//disable for now
+		//assertEquals("bar", e.getDefaultValue());
+		
+		//when function is disabled currently.
+		assertEquals(null, e.getDefaultValue());
+		
 	}
 
 }


### PR DESCRIPTION
doesn't consider the case when an attribute value is not present in some
of the nodes. Will re-implement this feature in the next release.