### PR TITLE
Merge tomcat10 branch into develop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,17 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junitVersion}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<!-- 3rd party libraries -->
 		<dependency>
@@ -43,19 +54,17 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.easymock</groupId>
 			<artifactId>easymock</artifactId>
-			<version>4.0.2</version>
+			<version>5.3.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -202,5 +211,6 @@
 		<jackson.version>2.17.1</jackson.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<swagger.version>2.2.21</swagger.version>
+		<junitVersion>5.10.2</junitVersion>
 	</properties>
 </project>

--- a/src/main/java/org/ndexbio/cx2/aspect/element/core/Cx2Network.java
+++ b/src/main/java/org/ndexbio/cx2/aspect/element/core/Cx2Network.java
@@ -14,7 +14,6 @@ import org.ndexbio.cx2.aspect.element.cytoscape.VisualEditorProperties;
 import org.ndexbio.cx2.io.CXReader;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class Cx2Network {
 	
@@ -92,10 +91,20 @@ public class Cx2Network {
 		
 	}
 
+	/**
+	 * Loads CX2 from InputStream passed in
+	 * 
+	 * @param in 
+	 * @throws JsonParseException If there is a JSON parsing error
+	 * @throws IOException If there is an IO error or if {@code in} is {@code null} 
+	 */
 	public Cx2Network (InputStream in) throws JsonParseException, IOException {
+		this();
+		if (in == null){
+			throw new IOException("InputStream cannot be null");
+		}
 		CXReader reader = new CXReader (in);
 		
-		ObjectMapper om = new ObjectMapper();
 		
 		for (CxAspectElement<?> elmt : reader) {
 				switch (elmt.getAspectName()) {


### PR DESCRIPTION
This pull request has a minor change to overloaded `CX2Network(InputStream in)` constructor call. Code now invokes `this()` to call default constructor (fixes NPE error due to not created nodes, edges, objects) and has a null check on `in`. Also added update in pom to use junit-bom (handles versions better) for junit 5