### PR TITLE
Resolve CYTOSCAPE-13147. Fixed a bug in the edge arrow shape converter.

### DIFF
--- a/src/main/java/org/ndexbio/cx2/converter/CX2ToCXVisualPropertyConverter.java
+++ b/src/main/java/org/ndexbio/cx2/converter/CX2ToCXVisualPropertyConverter.java
@@ -79,20 +79,26 @@ public class CX2ToCXVisualPropertyConverter {
 		private static final CX2ToCXVisualPropertyCvtFunction arrowShapeCvtr = (cytoscapeArrowShape) ->
 		{
 			switch ( cytoscapeArrowShape.toString() ) { 
-			case "none":
-				return "NONE";					
-			case "circle CIRCLE":
-				return "CIRCLE";
+		
 			case "triangle-cross":
 				return "CROSS_DELTA";
-			case "diamond":	
-				return "DIAMOND";
-			case "square":
-				return "SQUARE";
 			case "tee":
 				return "T";
+			case "triangle":
+				return "DELTA";
+			case "arrow":
+			case "circle":
+			case "cross_open_delta":
+			case "diamond":
+			case "none":
+			case "open_circle":
+			case "open_delta":
+			case "open_diamond":
+			case "open_square":
+			case "square":
+				return cytoscapeArrowShape.toString().toUpperCase(); 
 			default:
-				return "ARROW";	
+				throw new IllegalArgumentException("Unknown arrow shape: " + cytoscapeArrowShape);	
 				
 			} };						
 
@@ -297,10 +303,10 @@ public class CX2ToCXVisualPropertyConverter {
 	}
 
 	
-	public String getCx1EdgeOrNodePropertyValue (String cx2VPName, Object oldValue) {
+	public String getCx1EdgeOrNodePropertyValue (String cx2VPName, Object cx2Value) {
 		Map.Entry<String,CX2ToCXVisualPropertyCvtFunction> cvtr = nodeEdgeCvtTable.get(cx2VPName);
 		if ( cvtr != null)
-			return cvtr.getValue().convert(oldValue);
+			return cvtr.getValue().convert(cx2Value);
 		return null;
 	}
 	

--- a/src/main/java/org/ndexbio/cx2/converter/CXToCX2VisualPropertyConverter.java
+++ b/src/main/java/org/ndexbio/cx2/converter/CXToCX2VisualPropertyConverter.java
@@ -170,26 +170,25 @@ public class CXToCX2VisualPropertyConverter {
 				{
 					switch ( cytoscapeArrowShape ) { 
 					case "NONE":
-						return "none";					
+					case "ARROW": // this is a common value in Cytoscape, so we keep it.
 					case "CIRCLE":
-					case "OPEN_CIRCLE":
-						return "circle";
-					case "CROSS_DELTA":
-					case "CROSS_OPEN_DELTA":
-						return "triangle-cross";
 					case "DIAMOND":
+					case "OPEN_CIRCLE":
+					case "CROSS_OPEN_DELTA":
+					case "OPEN_DIAMOND":	
+					case "OPEN_SQUARE":
+					case "OPEN_DELTA":
+					case "SQUARE":
+						return cytoscapeArrowShape.toLowerCase();
+					case "CROSS_DELTA":
+						return "triangle-cross";
 					case "DIAMOND_SHORT_1":
 					case "DIAMOND_SHORT_2":
-					case "OPEN_DIAMOND":	
 						return "diamond";
-					case "OPEN_SQUARE":
-					case "SQUARE":
-						return "square";
 					case "T":
 						return "tee";
 					default:
 						/* covers these cases
-					case "ARROW":
 					case "ARROW_SHORT":
 					case "DELTA":
 					case "DELTA_SHORT_1":
@@ -197,7 +196,6 @@ public class CXToCX2VisualPropertyConverter {
 					case "HALF_BOTTOM":
 					case "HALF_CIRCLE":
 					case "HALF_TOP":
-					case "OPEN_DELTA":
 					case "OPEN_HALF_CIRCLE":	*/
 						return "triangle";	
 						

--- a/src/test/java/org/ndexbio/cx2/converter/CX2ToCXVisualPropertyConverterTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/CX2ToCXVisualPropertyConverterTest.java
@@ -128,5 +128,28 @@ public class CX2ToCXVisualPropertyConverterTest {
 		
 
 	}
+	
+	@Test
+	public void EdgeArrowShapeConverterTest() {
+		String vpName = "EDGE_SOURCE_ARROW_SHAPE";
+		Map<String,Object> edgeArrowShapeMap = new HashMap<>();
+		edgeArrowShapeMap.put("none", "NONE");
+		edgeArrowShapeMap.put("triangle", "DELTA");
+		edgeArrowShapeMap.put("circle", "CIRCLE");
+		edgeArrowShapeMap.put("diamond", "DIAMOND");
+		edgeArrowShapeMap.put("square", "SQUARE");
+		edgeArrowShapeMap.put("arrow", "ARROW");
+		edgeArrowShapeMap.put("tee", "T");
+		edgeArrowShapeMap.put("triangle-cross", "CROSS_DELTA");
+		edgeArrowShapeMap.put("cross_open_delta", "CROSS_OPEN_DELTA");
+		edgeArrowShapeMap.put("open_circle", "OPEN_CIRCLE");
+		edgeArrowShapeMap.put("open_delta", "OPEN_DELTA");
+		edgeArrowShapeMap.put("open_square", "OPEN_SQUARE");
+		edgeArrowShapeMap.put("open_diamond", "OPEN_DIAMOND");
+
+		edgeArrowShapeMap.forEach((k, v) -> {
+			assertEquals(v, CX2ToCXVisualPropertyConverter.getInstance().getCx1EdgeOrNodePropertyValue(vpName,k));
+		});
+	}
 
 }

--- a/src/test/java/org/ndexbio/cx2/converter/CXToCX2VisualPropertyConverterTest.java
+++ b/src/test/java/org/ndexbio/cx2/converter/CXToCX2VisualPropertyConverterTest.java
@@ -2,7 +2,9 @@ package org.ndexbio.cx2.converter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +66,45 @@ class CXToCX2VisualPropertyConverterTest {
 	    	assertEquals(HorizontalAlignment.left, gp.getJustification());
 	    	assertEquals(0.0, gp.getMarginX());
 	    	assertEquals(27.0, gp.getMarginY());
+	    	
+	    	
 	    }
 
+	    @Test
+	    void testConvertEdgeArrowShapeValues() throws NdexException {
+			// Prepare a sample input map for edge arrow shape values
+	    	Map<String, String> edgeArrowShapeValues = new HashMap<>();
+	    	edgeArrowShapeValues.put("ARROW", "arrow");
+	    	edgeArrowShapeValues.put("ARROW_SHORT", "triangle");
+	    	edgeArrowShapeValues.put("CIRCLE", "circle");
+	    	edgeArrowShapeValues.put("CROSS_DELTA", "triangle-cross");
+	    	edgeArrowShapeValues.put("CROSS_OPEN_DELTA", "cross_open_delta");
+	    	edgeArrowShapeValues.put("DELTA", "triangle");
+	    	edgeArrowShapeValues.put("DELTA_SHORT_1", "triangle");
+	    	edgeArrowShapeValues.put("DELTA_SHORT_2", "triangle");
+	    	edgeArrowShapeValues.put("DIAMOND", "diamond");
+	    	edgeArrowShapeValues.put("DIAMOND_SHORT_1", "diamond");
+	    	edgeArrowShapeValues.put("DIAMOND_SHORT_2", "diamond");
+	    	edgeArrowShapeValues.put("HALF_BOTTOM", "triangle");
+	    	edgeArrowShapeValues.put("HALF_CIRCLE", "triangle");
+	    	edgeArrowShapeValues.put("HALF_TOP", "triangle");
+	    	edgeArrowShapeValues.put("NONE", "none");
+	    	edgeArrowShapeValues.put("OPEN_CIRCLE", "open_circle");
+	    	edgeArrowShapeValues.put("OPEN_DELTA", "open_delta");
+	    	edgeArrowShapeValues.put("OPEN_DIAMOND", "open_diamond");
+	    	edgeArrowShapeValues.put("OPEN_HALF_CIRCLE", "triangle");
+	    	edgeArrowShapeValues.put("OPEN_SQUARE", "open_square");
+	    	edgeArrowShapeValues.put("SQUARE", "square");
+	    	edgeArrowShapeValues.put("T", "tee");
+	    	
+	    	String vpName = "EDGE_TARGET_ARROW_SHAPE";
+	    	
+			// Call the convertEdgeArrowShapeValues method
+			// Assert the expected
+			for (Map.Entry<String, String> entry : edgeArrowShapeValues.entrySet()) {
+				assertEquals(entry.getValue(), converter.getNewEdgeOrNodePropertyValue(vpName, entry.getKey()));
+			}
+	    	
+	    }
 	    // Additional tests for other methods and edge cases
 }


### PR DESCRIPTION
Also updated the cx2 <-> Cytoscape arrow shape converter to preserve all the shapes that can be rendered by Cytoscape JS.